### PR TITLE
Add support for sha256. Generalize for multiple hash types

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,16 @@ In no particular order:
 
 TSW is really just one file: `tsw.py`, and only requires a standard Python 3 installation to work. This section calls out two supported installation methods, though other ways to install+use certainly exist.
 
+Any expected sum values that are omitted are not checked, e.g. using just EXPECTED_SHA256_SUM will only validate the SHA256 sum, but not the SHA1.
+
 #### AWS Lambda (serverless)
 
 1. Create a new AWS Lambda python 3 application
 1. Copy the `tsw.py` code in for the Lambda code
 1. Add two config environment variables with the following Key:Value settings
    * TARGET_URL: <the URL of the artifact you want verified hasn't changed>
-   * EXPECTED_SUM: <the sum you are expecting the artifact to match, hex string format>
+   * EXPECTED_SUM: <the sha1 sum you are expecting the artifact to match, hex string format> (optional)
+   * EXPECTED_SHA256_SUM: <the sha256 sum you are expecting the artifact to match, hex string format> (optional)
 
 At this point, you can add a [time-based trigger](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-run-lambda-schedule.html) for your Lambda or whatever you like there. You can also set up [monitoring to take actions](https://aws.amazon.com/getting-started/hands-on/handle-serverless-application-errors-step-functions-lambda/) (like alerting!) when the current sum does not match the expected sum.
 
@@ -33,12 +36,12 @@ At this point, you can add a [time-based trigger](https://docs.aws.amazon.com/ev
 
 You can manually run TSW on a Linux commandline like so:
 
-`TARGET_URL="<http/https URL to hosted artifact to check>" EXPECTED_SUM="<sha1sum hex string value>" ./tsw.py`
+`TARGET_URL="<http/https URL to hosted artifact to check>" EXPECTED_SUM="<sha1sum hex string value>" EXPECTED_SHA256_SUM="<sha256sum hex string value> ./tsw.py`
 
 Example passing run:
 
 ```
-$ TARGET_URL="https://raw.githubusercontent.com/pbarry25/tsw/main/LICENSE" EXPECTED_SUM="620f9d32b2f1c11a1cd45181ba6ea055ff206b27" ./tsw.py
+$ TARGET_URL="https://raw.githubusercontent.com/pbarry25/tsw/main/LICENSE" EXPECTED_SUM="620f9d32b2f1c11a1cd45181ba6ea055ff206b27" EXPECTED_SHA256_SUM="e5784e879dc2c2a720bb0f71481d93de71e1a1a865ce5d8d008b208bc595033a" ./tsw.py
 $ echo $?
 0
 ```


### PR DESCRIPTION
Turns out I was writing this exact script when I saw your twitter post.

- Added support for SHA256
- sum_file expandable to other hash types. 